### PR TITLE
Fix: ignore properties of prototype

### DIFF
--- a/lib/reserved-words.js
+++ b/lib/reserved-words.js
@@ -49,7 +49,7 @@ exports.check = function check(word, dialect, strict) {
 
     assert(KEYWORDS[version], 'Unknown dialect');
 
-    return KEYWORDS[version][word];
+    return KEYWORDS[version].hasOwnProperty(word);
 };
 
 /**

--- a/test/reserved-words.js
+++ b/test/reserved-words.js
@@ -27,6 +27,10 @@ describe('reserved-words', function() {
         it('should return false for ES6 word', function() {
             assert(!reserved.check('await', dialect, strict));
         });
+
+        it('should return false for prototype word', function() {
+            assert(!reserved.check('toString', dialect, strict));
+        });
     });
 
     describe('es5 dialect', function() {


### PR DESCRIPTION
like `constructor`, `toString`, `valueOf`, etc.